### PR TITLE
[lodex-workers-python] Update ezs packages

### DIFF
--- a/applications/lodex-workers-python/Dockerfile
+++ b/applications/lodex-workers-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM inistcnrs/lodex-workers:9.2.3 AS build1
+FROM inistcnrs/lodex-workers:9.3.0 AS build1
 FROM golang:1.17.5-alpine3.15 as build2
 # System setup
 RUN apk update && \
@@ -12,10 +12,10 @@ RUN curl -L -o /tmp/protobuf.tar.gz $PROTOBUF_URL && \
 	cd /tmp/protobuf-3.3.0 && \
 	mkdir /export  && \
 	./autogen.sh && \
-    ./configure --prefix=/export && \
-    make -j 3 && \
-    make check && \
-    make install
+	./configure --prefix=/export && \
+	make -j 3 && \
+	make check && \
+	make install
 
 # Install protoc-gen-go
 RUN go get github.com/golang/protobuf/protoc-gen-go  && \
@@ -23,7 +23,7 @@ RUN go get github.com/golang/protobuf/protoc-gen-go  && \
 	cp /usr/lib/libstdc++* /export/lib/ && \
 	cp /usr/lib/libgcc_s* /export/lib/
 
-FROM node:14-alpine3.15 AS release
+FROM node:14-alpine3.17 AS release
 COPY --from=build1 /app /app
 COPY --from=build2 /export /usr
 WORKDIR /app
@@ -54,13 +54,13 @@ RUN apk add --update-cache --no-cache \
 	cython \
 	&& \
 	mv package-app.json package.json && \
-    npm install --production && \
+	npm install --production && \
 	npm cache clean --force && \
 	npm prune --production && \
 	echo '{ \
-		"httpPort": 31976, \
-			"configPath": "/app/config.json", \
-			"dataPath": "/app/public" \
+	"httpPort": 31976, \
+	"configPath": "/app/config.json", \
+	"dataPath": "/app/public" \
 	}' > /etc/ezmaster.json && \
 	sed -i -e "s/daemon:x:2:2/daemon:x:1:1/" /etc/passwd && \
 	sed -i -e "s/daemon:x:2:/daemon:x:1:/" /etc/group && \

--- a/applications/lodex-workers-python/README.md
+++ b/applications/lodex-workers-python/README.md
@@ -1,1 +1,1 @@
-# lodex-workers-python@4.0.11
+# lodex-workers-python@4.0.12

--- a/applications/lodex-workers-python/config.json
+++ b/applications/lodex-workers-python/config.json
@@ -13,11 +13,10 @@
 		"PIP_NO_CACHE_DIR": 0
 	},
 	"packages": [
-		"@ezs/spawn@1.1.0",
-		"@ezs/analytics@1.18.4",
-		"@ezs/basics@1.17.1"
+		"@ezs/spawn@1.2.31",
+		"@ezs/basics@2.0.0"
 	],
-	"files" : {
+	"files": {
 		"#DISABLED zip": "https://gitbucket.inist.fr/tdm/web-services/archive/base-line/master.zip"
 	}
 }

--- a/applications/lodex-workers-python/config.json
+++ b/applications/lodex-workers-python/config.json
@@ -12,10 +12,7 @@
 		"PIP_DISABLE_PIP_VERSION_CHECK": 1,
 		"PIP_NO_CACHE_DIR": 0
 	},
-	"packages": [
-		"@ezs/spawn@1.2.31",
-		"@ezs/basics@2.0.0"
-	],
+	"packages": [],
 	"files": {
 		"#DISABLED zip": "https://gitbucket.inist.fr/tdm/web-services/archive/base-line/master.zip"
 	}

--- a/applications/lodex-workers-python/package-app.json
+++ b/applications/lodex-workers-python/package-app.json
@@ -2,11 +2,9 @@
 	"private": true,
 	"name": "lodex-workers-python",
 	"dependencies": {
-		"@ezs/analytics": "1.18.4",
-		"@ezs/basics": "1.17.1",
-		"@ezs/core": "1.28.2",
-		"@ezs/spawn": "^1.2.2",
-		"@ezs/storage": "1.6.2",
+		"@ezs/basics": "2.0.0",
+		"@ezs/core": "2.5.1",
+		"@ezs/spawn": "^1.2.31",
 		"dotenv-cli": "4.1.1",
 		"npm-watch": "0.11.0"
 	},

--- a/applications/lodex-workers-python/package-app.json
+++ b/applications/lodex-workers-python/package-app.json
@@ -4,7 +4,7 @@
 	"dependencies": {
 		"@ezs/basics": "2.0.0",
 		"@ezs/core": "2.5.1",
-		"@ezs/spawn": "^1.2.31",
+		"@ezs/spawn": "1.2.31",
 		"dotenv-cli": "4.1.1",
 		"npm-watch": "0.11.0"
 	},

--- a/applications/lodex-workers-python/package.json
+++ b/applications/lodex-workers-python/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "lodex-workers-python",
-	"version": "4.0.11",
+	"version": "4.0.12",
 	"description": "Lodex workers for python",
 	"repository": {
 		"type": "git",

--- a/applications/lodex-workers-python/public/expand.ini
+++ b/applications/lodex-workers-python/public/expand.ini
@@ -16,8 +16,6 @@ post.parameters.1.description = Indent or not the JSON Result
 [use]
 plugin = @ezs/spawn
 plugin = @ezs/basics
-plugin = @ezs/storage
-plugin = @ezs/analytics
 
 [JSONParse]
 legacy = false


### PR DESCRIPTION
`@ezs/storage` is now useless, as it was needed only for `identify` statement, which was rewritten to be depencyless.

`@ezs/analysis` was needed for `expand` statement, which has been moved into `@ezs/core`.

Much debugging has been done on `ezs` since the last version (more than one year ago).